### PR TITLE
Show tank coordinates relative to arena size

### DIFF
--- a/PlayerBot.java
+++ b/PlayerBot.java
@@ -202,8 +202,8 @@ public class PlayerBot extends Bot {
         compassPanel.repaint();
 
         String stats = String.format(
-                "Energy: %.1f\nX: %.1f\nY: %.1f\nHeading: %.1f\nGun Heading: %.1f\nRadar Heading: %.1f\nGun Heat: %.1f\nSpeed: %.1f",
-                getEnergy(), getX(), getY(), botHeading, gunHeading,
+                "Energy: %.1f\nX: %.1f / %d\nY: %.1f / %d\nHeading: %.1f\nGun Heading: %.1f\nRadar Heading: %.1f\nGun Heat: %.1f\nSpeed: %.1f",
+                getEnergy(), getX(), getArenaWidth(), getY(), getArenaHeight(), botHeading, gunHeading,
                 getRadarDirection(), getGunHeat(), getSpeed());
 
         StringBuilder sb = new StringBuilder(stats).append("\n\nVisibility\n");


### PR DESCRIPTION
## Summary
- show the current X and Y positions relative to the arena width and height in the HUD

## Testing
- `javac -d build -cp "lib/*" PlayerBot.java Launcher.java`

------
https://chatgpt.com/codex/tasks/task_e_685d72b17224832b9465f030032f613f