### PR TITLE
Add round and turn info to PlayerBot HUD

### DIFF
--- a/PlayerBot.java
+++ b/PlayerBot.java
@@ -300,9 +300,9 @@ public class PlayerBot extends Bot {
         compassPanel.repaint();
 
         String stats = String.format(
-                "Energy: %.1f\nX: %.1f / %d\nY: %.1f / %d\nHeading: %.1f\nGun Heading: %.1f\nRadar Heading: %.1f\nGun Heat: %.1f\nSpeed: %.1f",
-                getEnergy(), getX(), getArenaWidth(), getY(), getArenaHeight(), botHeading, gunHeading,
-                getRadarDirection(), getGunHeat(), getSpeed());
+                "Round: %d / %d\nTurn: %d\nEnergy: %.1f\nX: %.1f / %d\nY: %.1f / %d\nHeading: %.1f\nGun Heading: %.1f\nRadar Heading: %.1f\nGun Heat: %.1f\nSpeed: %.1f",
+                getRoundNumber(), getNumberOfRounds(), getTurnNumber(), getEnergy(), getX(), getArenaWidth(),
+                getY(), getArenaHeight(), botHeading, gunHeading, getRadarDirection(), getGunHeat(), getSpeed());
 
         StringBuilder sb = new StringBuilder(stats).append("\n\nVisibility\n");
         if (enemies.isEmpty()) {


### PR DESCRIPTION
## Summary
- display current round number and turn count in the HUD

## Testing
- `javac -cp "lib/*" PlayerBot.java Launcher.java`

------
https://chatgpt.com/codex/tasks/task_e_685d9c68b270832ba1fe33985a054ba2