### PR TITLE
Allow PlayerBot jar to run directly when arguments provided

### DIFF
--- a/Launcher.java
+++ b/Launcher.java
@@ -3,6 +3,13 @@ import java.awt.event.*;
 
 public class Launcher {
     public static void main(String[] args) {
+        // If Robocode Tank Royale supplies the server URL and secret on the
+        // command line, skip the UI and start the bot immediately.
+        if (args.length >= 2) {
+            new PlayerBot(args[0], args[1]).start();
+            return;
+        }
+
         Frame frame = new Frame("PlayerBot Launcher");
         frame.setLayout(new GridLayout(3, 2));
 


### PR DESCRIPTION
## Summary
- ensure the launcher supports command line parameters
- bypass GUI when server URL and secret are supplied

## Testing
- `javac -d build -cp "lib/*" PlayerBot.java Launcher.java`


------
https://chatgpt.com/codex/tasks/task_e_685ed0cc81d0832b9e0e530e700c9134