### PR TITLE
Make PlayerBotLauncher.jar standalone

### DIFF
--- a/PlayerBot.java
+++ b/PlayerBot.java
@@ -164,7 +164,7 @@ public class PlayerBot extends Bot {
 
     // ── constructor ────────────────────────────────────────────────────
     public PlayerBot(String serverUrl, String serverSecret) {
-        super(BotInfo.fromFile("PlayerBot.json"), URI.create(serverUrl), serverSecret);
+        super(BotInfo.fromResourceFile("PlayerBot.json"), URI.create(serverUrl), serverSecret);
         // Add compass panel once the bot is constructed (static block already ran)
         infoFrame.add(compassPanel, BorderLayout.CENTER);
         infoFrame.validate();

--- a/README.md
+++ b/README.md
@@ -12,7 +12,9 @@ build.bat
 ```
 
 The resulting `PlayerBotLauncher.jar` will launch a small window where you can
-enter the server address and secret before connecting.
+enter the server address and secret before connecting. All dependencies and the
+bot configuration are bundled, so the jar can be moved and executed from any
+location.
 
 ## VS Code setup
 

--- a/build.bat
+++ b/build.bat
@@ -14,18 +14,24 @@ if errorlevel 1 (
 :: Step 3: Copy JSON config to build folder
 copy /Y PlayerBot.json build\ > nul
 
-:: Step 4: Detect bot API jar and create manifest file (2 lines!)
+:: Step 4: Detect bot API jar
 for %%F in (lib\robocode-tankroyale-bot-api-*.jar) do set "API_JAR=%%F"
 
+:: Step 5: Extract API jar into build folder
+pushd build
+jar xf ..\%API_JAR%
+rmdir /s /q META-INF 2>nul
+popd
+
+:: Step 6: Create manifest file
 > build\manifest.txt (
     echo Main-Class: Launcher
-    echo Class-Path: %API_JAR:\=/%
 )
 
-:: Step 5: Package JAR
+:: Step 7: Package JAR
 jar cfm PlayerBotLauncher.jar build\manifest.txt -C build .
 
-:: Step 6: Clean up
+:: Step 8: Clean up
 rmdir /s /q build
 
 endlocal


### PR DESCRIPTION
## Summary
- Embed PlayerBot configuration into the jar by loading it as a classpath resource
- Update build script to include bot API dependency and configuration so the jar runs standalone
- Document that the produced jar can be moved and executed from any location

## Testing
- `javac -d build -cp "lib/*" PlayerBot.java Launcher.java`


------
https://chatgpt.com/codex/tasks/task_e_689b9ac1da20832b90b3e9d46f2942c7